### PR TITLE
S-Kademlia Support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ pub use handshake_state::ReadError;
 pub use stateless_transport_state::StatelessTransportState;
 pub use transport_state::TransportState;
 pub use x25519_dalek as x25519;
+pub use symmetric::DiscoHash;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -333,7 +333,7 @@ impl Handshake {
         self.modifiers.fallback
     }
 
-    /// Wheather the pattern has a sig modifier.
+    /// Whether the pattern has a sig modifier.
     pub fn is_sig(&self) -> bool {
         self.modifiers.sig
     }

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -128,6 +128,16 @@ impl DiscoHash {
         self.strobe_ctx.prf(&mut buf, false);
         buf
     }
+
+    /// Random byte arrays
+    #[inline]
+    pub fn random(output_len: usize) -> Vec<u8> {
+        assert!(output_len >= 32);
+        let mut buf = vec![0u8; output_len];
+        rand::thread_rng().fill_bytes(&mut buf);
+        buf
+    }
+    
 }
 
 /// Hashes an input of any length and obtain an output of length greater or equal to

--- a/src/symmetric.rs
+++ b/src/symmetric.rs
@@ -1,6 +1,6 @@
 //! Symmetric crypto primitives built with strobe.
 use crate::constants::{NONCE_LEN, TAG_LEN};
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, RngCore, rngs::OsRng};
 pub use strobe_rs::AuthError;
 use strobe_rs::{SecParam, Strobe};
 
@@ -132,12 +132,10 @@ impl DiscoHash {
     /// Random byte arrays
     #[inline]
     pub fn random(output_len: usize) -> Vec<u8> {
-        assert!(output_len >= 32);
         let mut buf = vec![0u8; output_len];
-        rand::thread_rng().fill_bytes(&mut buf);
+        OsRng.fill_bytes(&mut buf);
         buf
     }
-    
 }
 
 /// Hashes an input of any length and obtain an output of length greater or equal to


### PR DESCRIPTION
## disco::symmetric::DiscoHash::random(output_len: usize) -> Vec<u8>

It will be useful to be able to generate random `NodeId`s for testing purposes (for s-kademlia). This will require generating random `DiscoHash`es, which are, according to `sum()`, just random `Vec<u8>`. So, I just added a random method which generates random `Vec<u8>`. I could also just put this logic in `NodeId`, but I suspect that it is common to call it from the hash library (for example, it is in parity multihash).